### PR TITLE
adds a block class that both food and segement inherit from

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -1,0 +1,10 @@
+class Block {
+  constructor(x, y){
+    this.x = x;
+    this.y = y;
+    this.height = 20;
+    this.width = 20;
+  }
+}
+
+module.exports = Block;

--- a/lib/food.js
+++ b/lib/food.js
@@ -1,8 +1,8 @@
-var Segment = require("./segment");
+var Block = require("./block");
 
-class Food extends Segment {
-  constructor(x, y, binary){
-    super(x, y);
+class Food extends Block {
+  constructor(x, y, height, width, binary){
+    super(x, y, height, width);
     this.binary = binary;
   }
 }

--- a/lib/game.js
+++ b/lib/game.js
@@ -3,7 +3,6 @@ var Snake = require("./snake");
 var UserInput = require("./userInput");
 var Food = require("./food");
 var Num = require("./num");
-// var scoreBoard = require("./scoreBoard")
 
 class Game {
   constructor(canvas, context) {
@@ -54,11 +53,10 @@ class Game {
     return proposedFoodLocation;
   }
 
-
   generateNewFoodItem(bitType) {
     var otherBit = bitType === 0 ? 1 : 0;
     var foodCoords = this.determineFoodLocation(otherBit);
-    var food = new Food(foodCoords.x, foodCoords.y, bitType);
+    var food = new Food(foodCoords.x, foodCoords.y, 20, 20, bitType);
     this.food[bitType] = food;
   }
 
@@ -110,7 +108,7 @@ class Game {
   }
 
   updateScore(num) {
-    if (num) { 
+    if (num) {
       this.score += num;
     } else {
     this.score++;

--- a/lib/segment.js
+++ b/lib/segment.js
@@ -1,9 +1,8 @@
-class Segment {
-  constructor(x, y) {
-    this.height = 20;
-    this.width = 20;
-    this.x = x;
-    this.y = y;
+var Block = require("./block");
+
+class Segment extends Block {
+  constructor(x, y, height, width){
+    super(x, y, height, width);
     this.prev = null;
   }
 }

--- a/test/block-test.js
+++ b/test/block-test.js
@@ -1,0 +1,36 @@
+const chai = require('chai');
+const assert = chai.assert;
+const Block = require('../lib/block');
+
+describe("Block", function(){
+
+  context("with default attributes", function(){
+
+    it('should be instantiated', function(){
+      let block = new Block(10, 10);
+      assert.isObject(block);
+    });
+
+    it('should have a height', function(){
+      let block = new Block(10, 10);
+      assert.equal(block.height, 20);
+    });
+
+    it('should have a width', function(){
+      let block = new Block(10, 10);
+      assert.equal(block.width, 20);
+    });
+
+  });
+
+  context("with passed attributes", function(){
+    it('should have a passed x-value', function(){
+      let block = new Block(10, 20);
+      assert.equal(block.x, 10);
+    });
+    it('should have a passed y-value', function(){
+      let block = new Block(10, 20);
+      assert.equal(block.y, 20);
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -7,3 +7,4 @@ require('./game-test');
 require('./num-test');
 require('./scoreboard-test');
 require('./menu-test');
+require('./block-test');

--- a/test/segment-test.js
+++ b/test/segment-test.js
@@ -1,12 +1,6 @@
 const chai = require('chai');
 const assert = chai.assert;
-
 const Segment = require('../lib/segment');
-
-// beforeEach(function(){
-//   var seg = new Segment(10, 10);
-//   return seg
-// })
 
 describe("Segment", function(){
 


### PR DESCRIPTION
Before:
We had a segment class for snake pieces and food class for food pieces.  
Food extended the segment class - because they shared almost all of the same characteristics.  
However, segment had a prev property that does not apply to food.

Now
There is a block class for all shared properties, food and segment inherit from it.
Tests continue to pass for segment and food
New tests added for block class.

All seems to be working IRL.

@pwentz @carmer
